### PR TITLE
Install & Activation checks for Gravity Forms. Better error reporting.

### DIFF
--- a/acf-gravity_forms.php
+++ b/acf-gravity_forms.php
@@ -26,5 +26,23 @@ function register_fields_Gravity_Forms() {
 
 add_action('acf/register_fields', 'register_fields_gravity_forms');
 
+//Added to check if Gravity Forms is installed on activation.
+function gff_activate() {
 
+    if (class_exists('RGFormsModel')) {
+			
+			return true;
+			
+		}	else {
+			
+			$html = '<div class="error">';
+				$html .= '<p>';
+					$html .= _e( 'Warning: Gravity Forms is not installed or activated. This plugin does not function without Gravity Forms!' );
+				$html .= '</p>';
+			$html .= '</div>';
+			echo $html;
+			
+		}
+}
+register_activation_hook( __FILE__, 'gff_activate' );
 ?>

--- a/gravity_forms-v4.php
+++ b/gravity_forms-v4.php
@@ -159,39 +159,34 @@ class acf_field_gravity_forms extends acf_field
 	*  @return	$value	- the modified value
 	*/
 
-	function format_value_for_api( $value, $post_id, $field )
-	{
-		// format value
-    if( !$value )
+	function format_value_for_api( $value, $field )
     {
-    	return false;
+
+    if(!$value || $value == 'null'){
+        return false;
+
     }
-
-
-    if( $value == 'null' )
-    {
-    	return false;
-    }
-
-
-    // load form data
-    if( is_array($value) )
-    {
-      foreach( $value as $k => $v )
-      {
-          $form = RGFormsModel::get_form($v);
-          $value[ $k ] = $form;
+    
+    //If there are multiple forms, construct and return an array of form markup
+    if(is_array($value)){
+        foreach($value as $k => $v){
+          $form = get_post($v);
+          $f = do_shortcode('[gravityform id="'.$form->ID.'" title="'.$form->post_title.'"]');
+          $value[$k] = array();
+          $value[$k] = $f;
         }
-    }
-    else
-    {
-    	$value = RGFormsModel::get_form($value);
+    //Else return single form markup
+
+    }else{
+
+        $form = get_post($value);
+        $value = do_shortcode('[gravityform id="'.$form->ID.'" title="'.$form->post_title.'"]');
     }
 
-
-    // return value
     return $value;
-	}
+
+    }
+
 }
 
 // create field

--- a/gravity_forms-v4.php
+++ b/gravity_forms-v4.php
@@ -116,10 +116,18 @@ class acf_field_gravity_forms extends acf_field
 		// vars
 		$field = array_merge($this->defaults, $field);
 		$choices = array();
-    $forms = RGFormsModel::get_forms(1);
+		//added class exists to show notice if Gravity Forms is not activated
+		if (class_exists('RGFormsModel')) {
+			
+			$forms = RGFormsModel::get_forms(1);
+			
+		}	else {
+			echo "<font style='color:red;font-weight:bold;'>Warning: Gravity Forms is not installed or activated. This field does not function without Gravity Forms!</font>";
+		}
+    
 
-
-    if($forms)
+	//Added isset to prevent undefined variable notice
+    if(isset($forms))
     {
     	foreach( $forms as $form )
     	{
@@ -169,10 +177,10 @@ class acf_field_gravity_forms extends acf_field
     // load form data
     if( is_array($value) )
     {
-    	foreach( $value as $k => $v )
-    	{
-        	$form = RGFormsModel::get_form($v);
-        	$value[ $k ] = $form;
+      foreach( $value as $k => $v )
+      {
+          $form = RGFormsModel::get_form($v);
+          $value[ $k ] = $form;
         }
     }
     else
@@ -188,5 +196,4 @@ class acf_field_gravity_forms extends acf_field
 
 // create field
 new acf_field_gravity_forms();
-
 ?>


### PR DESCRIPTION
Plugin cannot be activated if Gravity Forms is not activated or
installed. When it is activated, and GF is deactivated afterwards, the
user will get an error if they try to assign the form field. Also checks
if $forms isset to hide a undefined variable notice from the user.