### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "stormuk/gravityforms-acf-field",
+  "description": "Advanced Custom Field custom field to select one or many Gravity Forms",
+  "type": "wordpress-plugin",
+  "extra": {
+    "installer-name": "gravityforms-acf-field"
+  },
+  "homepage": "https://github.com/stormuk/Gravity-Forms-ACF-Field",
+  "license": "GPL-2.0",
+  "require": {
+    "composer/installers": "~1.0"
+  }
+}


### PR DESCRIPTION
With this composer.json the package can be used using composer. Preferably you would also add the package to [packagist](https://packagist.org).

License is GPL automatically because WordPress has a GPL license.
