### PR TITLE
Fixed format_value and minor tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Compatibility
 
 This add-on will work with:
 
-* version 4 and up
+* version 4
+* Version 5
 
 Installation
 ============
@@ -34,28 +35,37 @@ Using the field
 
 The field lets you pick one or many fields.
 
-The data returned is either a Form object or an array of [Form objects](http://www.gravityhelp.com/documentation/page/Form_Object).
+The data returned is either a Form object, an array of [Form objects](http://www.gravityhelp.com/documentation/page/Form_Object) or false if an error occurred.
 
 If you have selected a single form and you want to display the form on the page, you can use:
 
 ```
 <?php 
-    $form = get_field('your_form_field');
-    gravity_form_enqueue_scripts($form->id, true);
-    gravity_form($form->id, true, true, false, '', true, 1); 
+    $form_object = get_field('your_form_field');
+    gravity_form_enqueue_scripts($form_object['id'], true);
+    gravity_form($form_object['id'], true, true, false, '', true, 1); 
 ?>
 ```
 
-You can find out more about the gravity_form method to embed a form on a page in their [documentation](http://www.gravityhelp.com/documentation/page/Embedding_A_Form#Function_Call)
+or
+
+```
+<?php 
+    $form_object = get_field('your_form_field');
+    echo do_shortcode('[gravityform id="' . $form_object['id'] . '" title="true" description="true" ajax="true"]');
+?>
+```
+
+You can find out more about the gravity_form method to embed a form on a page in their [documentation](http://www.gravityhelp.com/documentation/page/Embedding_A_Form)
 
 If you are using the field to select multiple forms, you will have to iterate over the array.  You can then use the form object as you like:
 
 ```
 <?php
-    $forms = get_field('your_forms');
+    $form_objects = get_field('your_forms');
   
-    foreach($forms as $form){
-        echo $form->title;  
+    foreach($form_objects as $form){
+        echo $form['title'];  
     }
 ?>
 ```
@@ -66,7 +76,7 @@ If you are using the field to select multiple forms, you will have to iterate ov
 About
 =====
 
-Version: 1.1
+Version: 1.2
 
 Written by Adam Pope and Liam Gladdy of [Storm Consultancy](http://www.stormconsultancy.co.uk) and the amazing contributors on [Github](https://github.com/stormuk/Gravity-Forms-ACF-Field/graphs/contributors)
 

--- a/gravity_forms-v4.php
+++ b/gravity_forms-v4.php
@@ -161,36 +161,41 @@ class acf_field_gravity_forms extends acf_field
 	function format_value_for_api( $value, $field )
     {
 
-		//format_value
-		if( !$value )
-		{
-		  return $value;
-		}
-
-		if( $value == 'null' )
-		{
-		  return false;
+		//Return false if value is false, null or empty
+		if( !$value || empty($value) ){
+			return false;
 		}
 		
-		//If there are multiple forms, construct and return an array of form markup
-		if(is_array($value)){
+		//If there are multiple forms, construct and return an array of form objects
+		if( is_array($value) && !empty($value) ){
+			
+			$form_objects = array();
 			foreach($value as $k => $v){
 			  $form = GFAPI::get_form( $v );
-			  $f = do_shortcode('[gravityform id="'.$form['id'].'" title="'.$form['title'].'"]');
-			  $value[$k] = array();
-			  $value[$k] = $f;
+			  //Add it if it's not an error object
+			  if( !is_wp_error($form) ){
+				  $form_objects[$k] = $form;
+			  }
 			}
-		
-	    return $value;
+			//Return false if the array is empty
+			if( !empty($form_objects) ){
+				return $form_objects;	
+			}else{
+				return false;
+			}
 			
-		//Else return single form markup
-		} else{
-			//$value can be mixed, make it an int
-			$value = intval($value); 
-			//get the form object
-			$form = GFAPI::get_form( $value );
-			//we can directly echo the shortcode here
-			echo do_shortcode('[gravityform id="'.$form['id'].'" title="'.$form['title'].'"]');
+			
+		//Else return single form object
+		}else{
+
+			$form = GFAPI::get_form(intval($value));
+			//Return the form object if it's not an error object. Otherwise return false. 
+			if( !is_wp_error($form) ){
+				return $form;	
+			}else{
+				return false;
+			}
+			
 		}
 
     }


### PR DESCRIPTION
Changed the format_value function to now return either a single form object or an array of objects (or false if error or empty).
Also updated the readme a bit.

The echoing of shortcode as before resulted in 502 error in my local enviroment and also assumed settings for the field.

Signed-off-by: Jonathan de Jong jonathan@tigerton.se
